### PR TITLE
Futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-executors = "0.6"
+executors = "0.7"
 ```
 
 You can use, for example, the [crossbeam_workstealing_pool](https://docs.rs/executors/latest/executors/crossbeam_workstealing_pool/index.html) to schedule a number `n_jobs` over a number `n_workers` threads, and collect the results via an `mpsc::channel`.
@@ -59,7 +59,7 @@ You can enable support for pinning pool threads to particular CPU cores via the 
 
 ## Some Numbers
 
-The following are some example result from my desktop machine (Intel i7-4770 @ 3.40Ghz Quad-Core with HT (8 logical cores) with 16GB of RAM).
+The following are some example results from my desktop machine (Intel i7-4770 @ 3.40Ghz Quad-Core with HT (8 logical cores) with 16GB of RAM).
 *Note* that they are all from a single run and thus not particularly scientific and subject to whatever else was going on on my system during the run.
 
 Implementation abbreviations:
@@ -170,6 +170,6 @@ This corresponds to a very large internal workload in response to every external
 
 ## License
 
-Licensed under the terms of MIT license.
+Licensed under the terms of the MIT license.
 
 See [LICENSE](LICENSE) for details.

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["concurrency", "asynchronous"]
 license = "MIT"
 
 [features]
-default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults"]
+default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults", "futures-support"]
 
 threadpool-exec = ["threadpool"]
 cb-channel-exec = ["crossbeam-channel"]
@@ -32,6 +32,8 @@ ws-no-park = []
 
 thread-pinning = ["core_affinity"]
 
+futures-support = ["futures"]
+
 
 [dependencies]
 log 				= "0.4"
@@ -41,10 +43,10 @@ crossbeam-channel 	= {version = "0.4", optional = true}
 threadpool 			= {version = "1.7", optional = true}
 crossbeam-utils 	= {version = "0.7", optional = true}
 crossbeam-deque 	= {version = "0.7", optional = true}
-#time 				= {version = "0.2", optional = true, default-featurs = false, features = ["std", ""]}
 rand 				= {version = "0.7", optional = true}
 num_cpus 			= {version = "1.12", optional = true}
 core_affinity 		= {version = "0.5", optional = true}
+futures 			= {version = "0.3", optional = true}
 
 [dev-dependencies]
 env_logger 			= "0.7"

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -3,7 +3,7 @@ name = "executors"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Lars Kroll <lkroll@kth.se>"]
 edition = "2018"
 description = "A collection of high-performance task executors."

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -51,6 +51,7 @@ futures 			= {version = "0.3", optional = true}
 [dev-dependencies]
 env_logger 			= "0.7"
 version-sync 		= "0.8"
+bencher 			= "0.1.5"
 
 
 [badges]
@@ -60,3 +61,8 @@ version-sync 		= "0.8"
 maintenance = { status = "actively-developed" }
 
 travis-ci = { repository = "Bathtor/rust-executors", branch = "master" }
+
+[[bench]]
+name = "scheduler"
+path = "benches/scheduler.rs"
+harness = false

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["concurrency", "asynchronous"]
 license = "MIT"
 
 [features]
-default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults", "futures-support"]
+default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults"]
 
 threadpool-exec = ["threadpool"]
-cb-channel-exec = ["crossbeam-channel"]
-workstealing-exec = ["crossbeam-channel", "crossbeam-deque", "rand", "crossbeam-utils"]
+cb-channel-exec = ["crossbeam-channel", "async-task"]
+workstealing-exec = ["crossbeam-channel", "crossbeam-deque", "rand", "crossbeam-utils", "async-task"]
 defaults = ["num_cpus"]
 
 # In the workstealing executor, check the global queues every 1ms
@@ -31,8 +31,6 @@ ws-timed-fairness = [] #["time"]
 ws-no-park = []
 
 thread-pinning = ["core_affinity"]
-
-futures-support = ["futures"]
 
 
 [dependencies]
@@ -46,12 +44,14 @@ crossbeam-deque 	= {version = "0.7", optional = true}
 rand 				= {version = "0.7", optional = true}
 num_cpus 			= {version = "1.12", optional = true}
 core_affinity 		= {version = "0.5", optional = true}
-futures 			= {version = "0.3", optional = true}
+#futures 			= {version = "0.3", optional = true}
+async-task 			= {version = "3.0", optional = true}
 
 [dev-dependencies]
 env_logger 			= "0.7"
 version-sync 		= "0.8"
 criterion 			= "0.3"
+futures 			= "0.3"
 
 
 [badges]

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -51,7 +51,7 @@ futures 			= {version = "0.3", optional = true}
 [dev-dependencies]
 env_logger 			= "0.7"
 version-sync 		= "0.8"
-bencher 			= "0.1.5"
+criterion 			= "0.3"
 
 
 [badges]

--- a/executors/benches/scheduler.rs
+++ b/executors/benches/scheduler.rs
@@ -1,0 +1,213 @@
+//! Benchmark implementation details of the theaded scheduler. These benches are
+//! intended to be used as a form of regression testing and not as a general
+//! purpose benchmark demonstrating real-world performance.
+
+use executors::crossbeam_workstealing_pool;
+use executors::futures_executor::*;
+use executors::Executor;
+use futures::channel::oneshot;
+
+use bencher::{benchmark_group, benchmark_main, Bencher};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{mpsc, Arc};
+
+fn spawn_many(b: &mut Bencher) {
+    const NUM_SPAWN: usize = 10_000;
+
+    let rt = rt();
+
+    let (tx, rx) = mpsc::sync_channel(1);
+    let rem = Arc::new(AtomicUsize::new(0));
+
+    b.iter(|| {
+        rem.store(NUM_SPAWN, Relaxed);
+
+        //futures::executor::block_on(async {
+        for _ in 0..NUM_SPAWN {
+            let tx = tx.clone();
+            let rem = rem.clone();
+
+            rt.spawn(async move {
+                if 1 == rem.fetch_sub(1, Relaxed) {
+                    tx.send(()).unwrap();
+                }
+            });
+        }
+
+        let _ = rx.recv().unwrap();
+        //});
+    });
+
+    rt.shutdown().expect("shutdown");
+}
+
+// fn yield_many(b: &mut Bencher) {
+//     const NUM_YIELD: usize = 1_000;
+//     const TASKS: usize = 200;
+
+//     let rt = rt();
+
+//     let (tx, rx) = mpsc::sync_channel(TASKS);
+
+//     b.iter(move || {
+//         for _ in 0..TASKS {
+//             let tx = tx.clone();
+
+//             rt.spawn(async move {
+//                 for _ in 0..NUM_YIELD {
+//                     tokio::task::yield_now().await;
+//                 }
+
+//                 tx.send(()).unwrap();
+//             });
+//         }
+
+//         for _ in 0..TASKS {
+//             let _ = rx.recv().unwrap();
+//         }
+//     });
+// }
+
+fn ping_pong(b: &mut Bencher) {
+    const NUM_PINGS: usize = 1_000;
+
+    let rt = rt();
+
+    let (done_tx, done_rx) = mpsc::sync_channel(1000);
+    let rem = Arc::new(AtomicUsize::new(0));
+
+    b.iter(|| {
+        let done_tx = done_tx.clone();
+        let rem = rem.clone();
+        rem.store(NUM_PINGS, Relaxed);
+
+        futures::executor::block_on(async {
+            let rt_new = rt.clone();
+            rt.spawn(async move {
+                for _ in 0..NUM_PINGS {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
+                    let rt_new2 = rt_new.clone();
+                    rt_new.spawn(async move {
+                        let (tx1, rx1) = oneshot::channel();
+                        let (tx2, rx2) = oneshot::channel();
+
+                        rt_new2.spawn(async move {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        });
+
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Relaxed) {
+                            done_tx.send(()).unwrap();
+                        }
+                    });
+                }
+            });
+
+            done_rx.recv().unwrap();
+        });
+    });
+    rt.shutdown().expect("shutdown");
+}
+
+fn chained_spawn(b: &mut Bencher) {
+    const ITER: usize = 1_000;
+
+    let rt = rt();
+
+    fn iter(done_tx: mpsc::SyncSender<()>, n: usize) {
+        if n == 0 {
+            done_tx.send(()).unwrap();
+        } else {
+            let _ = crossbeam_workstealing_pool::execute_locally(move || {
+                iter(done_tx, n - 1);
+            });
+        }
+    }
+
+    let (done_tx, done_rx) = mpsc::sync_channel(1000);
+    let rt_inner = rt.clone();
+    b.iter(move || {
+        let done_tx = done_tx.clone();
+        rt_inner.execute(move || {
+            iter(done_tx, ITER);
+        });
+
+        done_rx.recv().unwrap();
+    });
+    rt.shutdown().expect("shutdown");
+}
+
+fn chained_spawn_no_local(b: &mut Bencher) {
+    const ITER: usize = 1_000;
+
+    let rt = rt();
+
+    fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
+        if n == 0 {
+            done_tx.send(()).unwrap();
+        } else {
+            let rt_new = rt.clone();
+            rt.execute(move || {
+                iter(rt_new, done_tx, n - 1);
+            });
+        }
+    }
+
+    let (done_tx, done_rx) = mpsc::sync_channel(1);
+    let rt_inner = rt.clone();
+    b.iter(move || {
+        let done_tx = done_tx.clone();
+        let rt_new = rt_inner.clone();
+        rt_inner.execute(move || {
+            iter(rt_new, done_tx, ITER);
+        });
+
+        done_rx.recv().unwrap();
+    });
+    rt.shutdown().expect("shutdown");
+}
+
+fn chained_spawn_async(b: &mut Bencher) {
+    const ITER: usize = 1_000;
+
+    let rt = rt();
+
+    fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
+        if n == 0 {
+            done_tx.send(()).unwrap();
+        } else {
+            let rt_new = rt.clone();
+            rt.spawn(async move {
+                iter(rt_new, done_tx, n - 1);
+            });
+        }
+    }
+
+    let (done_tx, done_rx) = mpsc::sync_channel(1);
+    let rt_inner = rt.clone();
+    b.iter(move || {
+        let done_tx = done_tx.clone();
+        //futures::executor::block_on(async {
+        let rt_new = rt_inner.clone();
+        rt_inner.spawn(async move {
+            iter(rt_new, done_tx, ITER);
+        });
+
+        done_rx.recv().unwrap();
+        //});
+    });
+    rt.shutdown().expect("shutdown");
+}
+
+fn rt() -> impl FuturesExecutor {
+    crossbeam_workstealing_pool::small_pool(4)
+}
+
+benchmark_group!(scheduler, chained_spawn, chained_spawn_no_local, chained_spawn_async);
+
+benchmark_main!(scheduler);

--- a/executors/benches/scheduler.rs
+++ b/executors/benches/scheduler.rs
@@ -2,44 +2,258 @@
 //! intended to be used as a form of regression testing and not as a general
 //! purpose benchmark demonstrating real-world performance.
 
-use executors::crossbeam_workstealing_pool;
 use executors::futures_executor::*;
-use executors::Executor;
-use futures::channel::oneshot;
 
-use bencher::{benchmark_group, benchmark_main, Bencher};
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::Relaxed;
-use std::sync::{mpsc, Arc};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 
-fn spawn_many(b: &mut Bencher) {
-    const NUM_SPAWN: usize = 10_000;
+const CHAINING_DEPTH: usize = 1000;
+const SPAWN_NUM: usize = 1000;
+const PINGS_NUM: usize = 1000;
 
-    let rt = rt();
+pub fn chained_spawn_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Chained Spawn");
+    group.throughput(Throughput::Elements(CHAINING_DEPTH as u64));
+    // CBWP
+    group.bench_function("Local Function CBWP", chained_spawn::local_function_cbwp);
+    group.bench_function(
+        "No-Local Function CBWP",
+        chained_spawn::no_local_function_cbwp,
+    );
+    group.bench_function("Async CBWP", chained_spawn::async_cbwp);
+    // CBCP
+    group.bench_function(
+        "No-Local Function CBCP",
+        chained_spawn::no_local_function_cbcp,
+    );
+    group.bench_function("Async CBCP", chained_spawn::async_cbcp);
+    group.finish();
+}
 
-    let (tx, rx) = mpsc::sync_channel(1);
-    let rem = Arc::new(AtomicUsize::new(0));
+pub fn spawn_many_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Spawn Many");
+    group.throughput(Throughput::Elements(SPAWN_NUM as u64));
+    // CBWP
+    group.bench_function("Local Function CBWP", spawn_many::function_cbwp);
+    group.bench_function("Async CBWP", spawn_many::async_cbwp);
+    // CBCP
+    group.bench_function("Local Function CBCP", spawn_many::function_cbcp);
+    group.bench_function("Async CBCP", spawn_many::async_cbcp);
+    group.finish();
+}
 
-    b.iter(|| {
-        rem.store(NUM_SPAWN, Relaxed);
+pub fn ping_pong_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Ping Pong");
+    group.throughput(Throughput::Elements(PINGS_NUM as u64));
+    // CBWP
+    //group.bench_function("Local Function CBWP", spawn_many::function_cbwp);
+    group.bench_function("Async CBWP", ping_pong::async_cbwp);
+    // CBCP
+    //group.bench_function("Local Function CBCP", spawn_many::function_cbcp);
+    group.bench_function("Async CBCP", ping_pong::async_cbcp);
+    group.finish();
+}
 
-        //futures::executor::block_on(async {
-        for _ in 0..NUM_SPAWN {
-            let tx = tx.clone();
-            let rem = rem.clone();
+mod chained_spawn {
+    use super::*;
+    use criterion::Bencher;
+    use std::sync::mpsc;
 
-            rt.spawn(async move {
-                if 1 == rem.fetch_sub(1, Relaxed) {
-                    tx.send(()).unwrap();
-                }
-            });
+    fn cbwp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_workstealing_pool::small_pool(4)
+    }
+
+    fn cbcp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_channel_pool::ThreadPool::new(4)
+    }
+
+    pub fn local_function_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        chained_spawn_fun(b, rt);
+    }
+
+    pub fn no_local_function_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        chained_spawn_no_local(b, rt);
+    }
+
+    pub fn async_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        chained_spawn_async(b, rt);
+    }
+
+    pub fn no_local_function_cbcp(b: &mut Bencher) {
+        let rt = cbcp_rt();
+        chained_spawn_no_local(b, rt);
+    }
+
+    pub fn async_cbcp(b: &mut Bencher) {
+        let rt = cbcp_rt();
+        chained_spawn_async(b, rt);
+    }
+
+    fn chained_spawn_fun(b: &mut Bencher, rt: impl FuturesExecutor) {
+        fn iter(done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                let _ = executors::crossbeam_workstealing_pool::execute_locally(move || {
+                    iter(done_tx, n - 1);
+                });
+            }
         }
 
-        let _ = rx.recv().unwrap();
-        //});
-    });
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        let rt_inner = rt.clone();
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            rt_inner.execute(move || {
+                iter(done_tx, CHAINING_DEPTH);
+            });
 
-    rt.shutdown().expect("shutdown");
+            done_rx.recv().unwrap();
+        });
+        rt.shutdown().expect("shutdown");
+    }
+
+    fn chained_spawn_no_local(b: &mut Bencher, rt: impl FuturesExecutor) {
+        fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                let rt_new = rt.clone();
+                rt.execute(move || {
+                    iter(rt_new, done_tx, n - 1);
+                });
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        let rt_inner = rt.clone();
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            let rt_new = rt_inner.clone();
+            rt_inner.execute(move || {
+                iter(rt_new, done_tx, CHAINING_DEPTH);
+            });
+
+            done_rx.recv().unwrap();
+        });
+        rt.shutdown().expect("shutdown");
+    }
+
+    fn chained_spawn_async(b: &mut Bencher, rt: impl FuturesExecutor) {
+        fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                let rt_new = rt.clone();
+                rt.spawn(async move {
+                    iter(rt_new, done_tx, n - 1);
+                });
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        let rt_inner = rt.clone();
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            futures::executor::block_on(async {
+                let rt_new = rt_inner.clone();
+                rt_inner.spawn(async move {
+                    iter(rt_new, done_tx, CHAINING_DEPTH);
+                });
+
+                done_rx.recv().unwrap();
+            });
+        });
+        rt.shutdown().expect("shutdown");
+    }
+}
+
+mod spawn_many {
+    use super::*;
+    use criterion::Bencher;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering::Relaxed;
+    use std::sync::{mpsc, Arc};
+
+    fn cbwp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_workstealing_pool::small_pool(8)
+    }
+
+    fn cbcp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_channel_pool::ThreadPool::new(8)
+    }
+
+    pub fn function_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        spawn_many_function(b, rt);
+    }
+
+    pub fn async_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        spawn_many_async(b, rt);
+    }
+
+    pub fn function_cbcp(b: &mut Bencher) {
+        let rt = cbcp_rt();
+        spawn_many_function(b, rt);
+    }
+
+    pub fn async_cbcp(b: &mut Bencher) {
+        let rt = cbcp_rt();
+        spawn_many_async(b, rt);
+    }
+
+    fn spawn_many_function(b: &mut Bencher, rt: impl FuturesExecutor) {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            rem.store(SPAWN_NUM, Relaxed);
+
+            for _ in 0..SPAWN_NUM {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                rt.execute(move || {
+                    if 1 == rem.fetch_sub(1, Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+
+        rt.shutdown().expect("shutdown");
+    }
+
+    fn spawn_many_async(b: &mut Bencher, rt: impl FuturesExecutor) {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            rem.store(SPAWN_NUM, Relaxed);
+
+            futures::executor::block_on(async {
+                for _ in 0..SPAWN_NUM {
+                    let tx = tx.clone();
+                    let rem = rem.clone();
+
+                    rt.spawn(async move {
+                        if 1 == rem.fetch_sub(1, Relaxed) {
+                            tx.send(()).unwrap();
+                        }
+                    });
+                }
+
+                let _ = rx.recv().unwrap();
+            });
+        });
+
+        rt.shutdown().expect("shutdown");
+    }
 }
 
 // fn yield_many(b: &mut Bencher) {
@@ -69,23 +283,66 @@ fn spawn_many(b: &mut Bencher) {
 //     });
 // }
 
-fn ping_pong(b: &mut Bencher) {
-    const NUM_PINGS: usize = 1_000;
+mod ping_pong {
 
-    let rt = rt();
+    use super::*;
+    use criterion::Bencher;
+    use futures::channel::oneshot;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering::SeqCst;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
 
-    let (done_tx, done_rx) = mpsc::sync_channel(1000);
-    let rem = Arc::new(AtomicUsize::new(0));
+    fn cbwp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_workstealing_pool::small_pool(4)
+    }
 
-    b.iter(|| {
-        let done_tx = done_tx.clone();
-        let rem = rem.clone();
-        rem.store(NUM_PINGS, Relaxed);
+    fn cbcp_rt() -> impl FuturesExecutor {
+        executors::crossbeam_channel_pool::ThreadPool::new(4)
+    }
 
-        futures::executor::block_on(async {
+    // pub fn local_function_cbwp(b: &mut Bencher) {
+    //     let rt = cbwp_rt();
+    //     chained_spawn_fun(b, rt);
+    // }
+
+    // pub fn no_local_function_cbwp(b: &mut Bencher) {
+    //     let rt = cbwp_rt();
+    //     chained_spawn_no_local(b, rt);
+    // }
+
+    pub fn async_cbwp(b: &mut Bencher) {
+        let rt = cbwp_rt();
+        ping_pong_async(b, rt);
+    }
+
+    // pub fn no_local_function_cbcp(b: &mut Bencher) {
+    //     let rt = cbcp_rt();
+    //     chained_spawn_no_local(b, rt);
+    // }
+
+    pub fn async_cbcp(b: &mut Bencher) {
+        let rt = cbcp_rt();
+        ping_pong_async(b, rt);
+    }
+
+    fn ping_pong_async(b: &mut Bencher, rt: impl FuturesExecutor) {
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        let mut count = 0u64;
+
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            let outer_rem = rem.clone();
+            rem.store(PINGS_NUM, SeqCst);
+            count += 1u64;
+            //println!("Iteration #{}", count);
+            //futures::executor::block_on(async {
             let rt_new = rt.clone();
             rt.spawn(async move {
-                for _ in 0..NUM_PINGS {
+                for _i in 0..PINGS_NUM {
                     let rem = rem.clone();
                     let done_tx = done_tx.clone();
                     let rt_new2 = rt_new.clone();
@@ -101,118 +358,34 @@ fn ping_pong(b: &mut Bencher) {
                         tx1.send(()).unwrap();
                         rx2.await.unwrap();
 
-                        if 1 == rem.fetch_sub(1, Relaxed) {
-                            done_tx.send(()).unwrap();
+                        let res = rem.fetch_sub(1, SeqCst);
+                        if 1 == res {
+                            done_tx.try_send(()).expect("done should have sent");
                         }
+                        // else {
+                        //     println!("Pinger {} is done, but {} remaining.", i, res);
+                        // }
                     });
                 }
             });
 
-            done_rx.recv().unwrap();
+            let res = done_rx.recv_timeout(Duration::from_millis(5000)); //.expect("should have gotten a done with 5s");
+            if res.is_err() {
+                panic!(
+                    "done_rx timeouted within 5s. Remaining={}",
+                    outer_rem.load(SeqCst)
+                );
+            }
+            //});
         });
-    });
-    rt.shutdown().expect("shutdown");
-}
-
-fn chained_spawn(b: &mut Bencher) {
-    const ITER: usize = 1_000;
-
-    let rt = rt();
-
-    fn iter(done_tx: mpsc::SyncSender<()>, n: usize) {
-        if n == 0 {
-            done_tx.send(()).unwrap();
-        } else {
-            let _ = crossbeam_workstealing_pool::execute_locally(move || {
-                iter(done_tx, n - 1);
-            });
-        }
+        rt.shutdown().expect("shutdown");
     }
-
-    let (done_tx, done_rx) = mpsc::sync_channel(1000);
-    let rt_inner = rt.clone();
-    b.iter(move || {
-        let done_tx = done_tx.clone();
-        rt_inner.execute(move || {
-            iter(done_tx, ITER);
-        });
-
-        done_rx.recv().unwrap();
-    });
-    rt.shutdown().expect("shutdown");
 }
 
-fn chained_spawn_no_local(b: &mut Bencher) {
-    const ITER: usize = 1_000;
-
-    let rt = rt();
-
-    fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
-        if n == 0 {
-            done_tx.send(()).unwrap();
-        } else {
-            let rt_new = rt.clone();
-            rt.execute(move || {
-                iter(rt_new, done_tx, n - 1);
-            });
-        }
-    }
-
-    let (done_tx, done_rx) = mpsc::sync_channel(1);
-    let rt_inner = rt.clone();
-    b.iter(move || {
-        let done_tx = done_tx.clone();
-        let rt_new = rt_inner.clone();
-        rt_inner.execute(move || {
-            iter(rt_new, done_tx, ITER);
-        });
-
-        done_rx.recv().unwrap();
-    });
-    rt.shutdown().expect("shutdown");
-}
-
-fn chained_spawn_async(b: &mut Bencher) {
-    const ITER: usize = 1_000;
-
-    let rt = rt();
-
-    fn iter(rt: impl FuturesExecutor, done_tx: mpsc::SyncSender<()>, n: usize) {
-        if n == 0 {
-            done_tx.send(()).unwrap();
-        } else {
-            let rt_new = rt.clone();
-            rt.spawn(async move {
-                iter(rt_new, done_tx, n - 1);
-            });
-        }
-    }
-
-    let (done_tx, done_rx) = mpsc::sync_channel(1);
-    let rt_inner = rt.clone();
-    b.iter(move || {
-        let done_tx = done_tx.clone();
-        //futures::executor::block_on(async {
-        let rt_new = rt_inner.clone();
-        rt_inner.spawn(async move {
-            iter(rt_new, done_tx, ITER);
-        });
-
-        done_rx.recv().unwrap();
-        //});
-    });
-    rt.shutdown().expect("shutdown");
-}
-
-fn rt() -> impl FuturesExecutor {
-    crossbeam_workstealing_pool::small_pool(4)
-}
-
-benchmark_group!(
+criterion_group!(
     scheduler,
-    chained_spawn,
-    chained_spawn_no_local,
-    chained_spawn_async
+    chained_spawn_benchmark,
+    spawn_many_benchmark,
+    ping_pong_benchmark
 );
-
-benchmark_main!(scheduler);
+criterion_main!(scheduler);

--- a/executors/benches/scheduler.rs
+++ b/executors/benches/scheduler.rs
@@ -208,6 +208,11 @@ fn rt() -> impl FuturesExecutor {
     crossbeam_workstealing_pool::small_pool(4)
 }
 
-benchmark_group!(scheduler, chained_spawn, chained_spawn_no_local, chained_spawn_async);
+benchmark_group!(
+    scheduler,
+    chained_spawn,
+    chained_spawn_no_local,
+    chained_spawn_async
+);
 
 benchmark_main!(scheduler);

--- a/executors/src/bichannel.rs
+++ b/executors/src/bichannel.rs
@@ -37,6 +37,10 @@ pub fn bichannel<Left, Right>() -> (Endpoint<Right, Left>, Endpoint<Left, Right>
     (endpoint_left, endpoint_right)
 }
 
+/// One end of a bichannel
+///
+/// This end can send `In` type to the other end
+/// and receive `Out` type from the other end.
 pub struct Endpoint<In, Out> {
     sender: Sender<Out>,
     receiver: Receiver<In>,
@@ -46,32 +50,52 @@ impl<In, Out> Endpoint<In, Out> {
     fn new(sender: Sender<Out>, receiver: Receiver<In>) -> Endpoint<In, Out> {
         Endpoint { sender, receiver }
     }
+
+    /// Send `t` to the other end
+    ///
+    /// This functions works just like [mpsc send](std::sync::mpsc::Sender::send).
     pub fn send(&self, t: Out) -> Result<(), SendError<Out>> {
         self.sender.send(t)
     }
+
+    /// Receive something from the channel without blocking
+    ///
+    /// This functions works just like [mpsc try_recv](std::sync::mpsc::Receiver::try_recv).
     pub fn try_recv(&self) -> Result<In, TryRecvError> {
         self.receiver.try_recv()
     }
+
+    /// Receive something from the channel, blocking until something is available
+    ///
+    /// This functions works just like [mpsc recv](std::sync::mpsc::Receiver::recv).
     pub fn recv(&self) -> Result<In, RecvError> {
         self.receiver.recv()
     }
+
+    /// Receive something from the channel, blocking until something is available or the timeout expires
+    ///
+    /// This functions works just like [mpsc recv_timeout](std::sync::mpsc::Receiver::recv_timeout).
     pub fn recv_timeout(&self, timeout: Duration) -> Result<In, RecvTimeoutError> {
         self.receiver.recv_timeout(timeout)
     }
+
+    /// Iterate over incoming data
+    ///
+    /// This functions works just like [mpsc iter](std::sync::mpsc::Receiver::iter).
     pub fn iter(&self) -> Iter<'_, In> {
         self.receiver.iter()
     }
+
+    /// Iterate over incoming data
+    ///
+    /// This functions works just like [mpsc try_iter](std::sync::mpsc::Receiver::try_iter).
     pub fn try_iter(&self) -> TryIter<'_, In> {
         self.receiver.try_iter()
     }
 }
 
-//impl<In, Out> !Sync for Endpoint<In, Out> {}
-unsafe impl<In: Send, Out: Send> Send for Endpoint<In, Out> {}
-
 #[cfg(test)]
 mod tests {
-    use env_logger;
 
     use super::*;
     use crate::common::ignore;

--- a/executors/src/common.rs
+++ b/executors/src/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/common.rs
+++ b/executors/src/common.rs
@@ -6,6 +6,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The core traits and reusable functions of this crate.
+
 use std::fmt::Debug;
 
 /// A minimal trait for task executors.

--- a/executors/src/crossbeam_channel_pool.rs
+++ b/executors/src/crossbeam_channel_pool.rs
@@ -241,9 +241,12 @@ impl Executor for ThreadPool {
 }
 
 impl FuturesExecutor for ThreadPool {
-    fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) -> () {
+    fn spawn<R: Send + 'static>(
+        &self,
+        future: impl Future<Output = R> + 'static + Send,
+    ) -> JoinHandle<R> {
         let exec = self.clone();
-        let (task, _handle) = async_task::spawn(
+        let (task, handle) = async_task::spawn(
             future,
             move |task| {
                 exec.schedule_task(task);
@@ -251,6 +254,7 @@ impl FuturesExecutor for ThreadPool {
             (),
         );
         task.schedule();
+        handle
     }
 }
 

--- a/executors/src/crossbeam_channel_pool.rs
+++ b/executors/src/crossbeam_channel_pool.rs
@@ -55,6 +55,9 @@ use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::time::Duration;
 
+/// A handle to a [crossbeam_channel_pool](crossbeam_channel_pool)
+///
+/// See module level documentation for usage information.
 #[derive(Clone, Debug)]
 pub struct ThreadPool {
     core: Arc<Mutex<ThreadPoolCore>>,

--- a/executors/src/crossbeam_channel_pool.rs
+++ b/executors/src/crossbeam_channel_pool.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/crossbeam_workstealing_pool.rs
+++ b/executors/src/crossbeam_workstealing_pool.rs
@@ -74,7 +74,6 @@ use crate::parker::{DynParker, ParkResult, Parker};
 use rand::prelude::*;
 use std::cell::UnsafeCell;
 use std::collections::BTreeMap;
-use std::collections::LinkedList;
 use std::fmt::{Debug, Formatter};
 use std::iter::{FromIterator, IntoIterator};
 use std::ops::Deref;

--- a/executors/src/crossbeam_workstealing_pool.rs
+++ b/executors/src/crossbeam_workstealing_pool.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/crossbeam_workstealing_pool.rs
+++ b/executors/src/crossbeam_workstealing_pool.rs
@@ -427,9 +427,12 @@ impl<P> FuturesExecutor for ThreadPool<P>
 where
     P: Parker + Clone + 'static,
 {
-    fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) -> () {
+    fn spawn<R: Send + 'static>(
+        &self,
+        future: impl Future<Output = R> + 'static + Send,
+    ) -> JoinHandle<R> {
         let exec = self.clone();
-        let (task, _handle) = async_task::spawn(
+        let (task, handle) = async_task::spawn(
             future,
             move |task| {
                 exec.schedule_task(task);
@@ -437,6 +440,7 @@ where
             (),
         );
         task.schedule();
+        handle
     }
 }
 

--- a/executors/src/futures_executor.rs
+++ b/executors/src/futures_executor.rs
@@ -15,8 +15,8 @@ use std::{
     cell::UnsafeCell,
     future::Future,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+        Arc,
     },
     task::{Context, Poll},
 };
@@ -46,120 +46,6 @@ where
         self.execute(move || FunTask::run(task));
     }
 }
-
-// pub(crate) struct FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     future: Mutex<Option<BoxFuture<'static, ()>>>,
-//     executor: E,
-// }
-
-// impl<E> FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     fn run(task: Arc<Self>) -> () {
-//         // let res = unsafe {
-//         //     let src = task.future.get();
-//         //     src.as_mut().map(|opt| opt.take()).flatten()
-//         // };
-//         let mut guard = task.future.lock().unwrap();
-//         if let Some(mut f) = guard.take() {
-//             let waker = waker_ref(&task);
-//             let context = &mut Context::from_waker(&*waker);
-//             // `BoxFuture<T>` is a type alias for
-//             // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
-//             // We can get a `Pin<&mut dyn Future + Send + 'static>`
-//             // from it by calling the `Pin::as_mut` method.
-//             if let Poll::Pending = f.as_mut().poll(context) {
-//                 // We're not done processing the future, so put it
-//                 // back in its task to be run again in the future.
-//                 // unsafe {
-//                 //     let dst = task.future.get();
-//                 //     if let Some(slot) = dst.as_mut() {
-//                 //         *slot = Some(f);
-//                 //     }
-//                 // }
-//                 *guard = Some(f);
-//             }
-//         } // else the future is already done with
-//     }
-// }
-
-// impl<E> ArcWake for FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     fn wake_by_ref(arc_self: &Arc<Self>) {
-//         // Implement `wake` by sending this task back onto the task channel
-//         // so that it will be polled again by the executor.
-//         let cloned = arc_self.clone();
-//         arc_self.executor.execute(move || FunTask::run(cloned));
-//     }
-// }
-
-// pub(crate) struct FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     future: UnsafeCell<Option<BoxFuture<'static, ()>>>,
-//     scheduled: AtomicBool,
-//     executor: E,
-// }
-
-// impl<E> FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     fn run(task: Arc<Self>) -> () {
-//         let res = unsafe {
-//             let src = task.future.get();
-//             src.as_mut().map(|opt| opt.take()).flatten()
-//         };
-//         if let Some(mut f) = res {
-//             let waker = waker_ref(&task);
-//             let context = &mut Context::from_waker(&*waker);
-//             // `BoxFuture<T>` is a type alias for
-//             // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
-//             // We can get a `Pin<&mut dyn Future + Send + 'static>`
-//             // from it by calling the `Pin::as_mut` method.
-//             if let Poll::Pending = f.as_mut().poll(context) {
-//                 // We're not done processing the future, so put it
-//                 // back in its task to be run again in the future.
-//                 unsafe {
-//                     let dst = task.future.get();
-//                     if let Some(slot) = dst.as_mut() {
-//                         *slot = Some(f);
-//                     }
-//                 }
-//             }
-//         } else {
-//             // else the future is already done with
-//             //unreachable!("Shouldn't get here!");
-//             //eprintln!("Future got schedulled despite being done!");
-//         }
-//         task.scheduled.store(false, Ordering::Release);
-//     }
-// }
-
-// impl<E> ArcWake for FunTask<E>
-// where
-//     E: Executor + Sync + 'static,
-// {
-//     fn wake_by_ref(arc_self: &Arc<Self>) {
-//         // Implement `wake` by sending this task back onto the task channel
-//         // so that it will be polled again by the executor.
-//         while arc_self
-//             .scheduled
-//             .compare_and_swap(false, true, Ordering::Acquire)
-//         {
-//             // hot wait here, since this only coveres the range between pool and the end of the function, where nothing expensive happens
-//         }
-//         let cloned = arc_self.clone();
-//         arc_self.executor.execute(move || FunTask::run(cloned));
-//     }
-// }
 
 pub(crate) struct FunTask<E>
 where

--- a/executors/src/futures_executor.rs
+++ b/executors/src/futures_executor.rs
@@ -14,9 +14,18 @@ use futures::{
 use std::{
     cell::UnsafeCell,
     future::Future,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
     task::{Context, Poll},
 };
+
+mod task_state {
+    pub const WAITING: usize = 0;
+    pub const SCHEDULED: usize = 1;
+    pub const DONE: usize = 2;
+}
 
 pub trait FuturesExecutor: Executor + Sync + 'static {
     fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) -> ();
@@ -29,6 +38,8 @@ where
         let future = future.boxed();
         let task = FunTask {
             future: UnsafeCell::new(Some(future)),
+            //future: Mutex::new(Some(future)),
+            state: AtomicUsize::new(task_state::SCHEDULED),
             executor: self.clone(),
         };
         let task = Arc::new(task);
@@ -36,11 +47,126 @@ where
     }
 }
 
+// pub(crate) struct FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     future: Mutex<Option<BoxFuture<'static, ()>>>,
+//     executor: E,
+// }
+
+// impl<E> FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     fn run(task: Arc<Self>) -> () {
+//         // let res = unsafe {
+//         //     let src = task.future.get();
+//         //     src.as_mut().map(|opt| opt.take()).flatten()
+//         // };
+//         let mut guard = task.future.lock().unwrap();
+//         if let Some(mut f) = guard.take() {
+//             let waker = waker_ref(&task);
+//             let context = &mut Context::from_waker(&*waker);
+//             // `BoxFuture<T>` is a type alias for
+//             // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
+//             // We can get a `Pin<&mut dyn Future + Send + 'static>`
+//             // from it by calling the `Pin::as_mut` method.
+//             if let Poll::Pending = f.as_mut().poll(context) {
+//                 // We're not done processing the future, so put it
+//                 // back in its task to be run again in the future.
+//                 // unsafe {
+//                 //     let dst = task.future.get();
+//                 //     if let Some(slot) = dst.as_mut() {
+//                 //         *slot = Some(f);
+//                 //     }
+//                 // }
+//                 *guard = Some(f);
+//             }
+//         } // else the future is already done with
+//     }
+// }
+
+// impl<E> ArcWake for FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     fn wake_by_ref(arc_self: &Arc<Self>) {
+//         // Implement `wake` by sending this task back onto the task channel
+//         // so that it will be polled again by the executor.
+//         let cloned = arc_self.clone();
+//         arc_self.executor.execute(move || FunTask::run(cloned));
+//     }
+// }
+
+// pub(crate) struct FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     future: UnsafeCell<Option<BoxFuture<'static, ()>>>,
+//     scheduled: AtomicBool,
+//     executor: E,
+// }
+
+// impl<E> FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     fn run(task: Arc<Self>) -> () {
+//         let res = unsafe {
+//             let src = task.future.get();
+//             src.as_mut().map(|opt| opt.take()).flatten()
+//         };
+//         if let Some(mut f) = res {
+//             let waker = waker_ref(&task);
+//             let context = &mut Context::from_waker(&*waker);
+//             // `BoxFuture<T>` is a type alias for
+//             // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
+//             // We can get a `Pin<&mut dyn Future + Send + 'static>`
+//             // from it by calling the `Pin::as_mut` method.
+//             if let Poll::Pending = f.as_mut().poll(context) {
+//                 // We're not done processing the future, so put it
+//                 // back in its task to be run again in the future.
+//                 unsafe {
+//                     let dst = task.future.get();
+//                     if let Some(slot) = dst.as_mut() {
+//                         *slot = Some(f);
+//                     }
+//                 }
+//             }
+//         } else {
+//             // else the future is already done with
+//             //unreachable!("Shouldn't get here!");
+//             //eprintln!("Future got schedulled despite being done!");
+//         }
+//         task.scheduled.store(false, Ordering::Release);
+//     }
+// }
+
+// impl<E> ArcWake for FunTask<E>
+// where
+//     E: Executor + Sync + 'static,
+// {
+//     fn wake_by_ref(arc_self: &Arc<Self>) {
+//         // Implement `wake` by sending this task back onto the task channel
+//         // so that it will be polled again by the executor.
+//         while arc_self
+//             .scheduled
+//             .compare_and_swap(false, true, Ordering::Acquire)
+//         {
+//             // hot wait here, since this only coveres the range between pool and the end of the function, where nothing expensive happens
+//         }
+//         let cloned = arc_self.clone();
+//         arc_self.executor.execute(move || FunTask::run(cloned));
+//     }
+// }
+
 pub(crate) struct FunTask<E>
 where
     E: Executor + Sync + 'static,
 {
     future: UnsafeCell<Option<BoxFuture<'static, ()>>>,
+    state: AtomicUsize,
     executor: E,
 }
 
@@ -69,8 +195,16 @@ where
                         *slot = Some(f);
                     }
                 }
+                task.state.store(task_state::WAITING, Ordering::Release);
+            } else {
+                task.state.store(task_state::DONE, Ordering::Release);
             }
-        } // else the future is already done with
+        } else {
+            // else the future is already done with
+            //unreachable!("Shouldn't get here!");
+            //eprintln!("Future got schedulled despite being done!");
+            task.state.store(task_state::DONE, Ordering::Release);
+        }
     }
 }
 
@@ -81,12 +215,33 @@ where
     fn wake_by_ref(arc_self: &Arc<Self>) {
         // Implement `wake` by sending this task back onto the task channel
         // so that it will be polled again by the executor.
-        let cloned = arc_self.clone();
-        arc_self.executor.execute(move || FunTask::run(cloned));
+
+        loop {
+            // hot wait here, since this only coveres the range between pool and the end of the function, where nothing expensive happens
+            let state = arc_self.state.compare_and_swap(
+                task_state::WAITING,
+                task_state::SCHEDULED,
+                Ordering::Acquire,
+            );
+            match state {
+                task_state::WAITING => {
+                    let cloned = arc_self.clone();
+                    arc_self.executor.execute(move || FunTask::run(cloned));
+                    return;
+                }
+                task_state::SCHEDULED => {
+                    continue;
+                }
+                task_state::DONE => {
+                    return;
+                }
+                _ => unreachable!("Invalid State!"),
+            }
+        }
     }
 }
 
-// I'm making sure only one thread at a time has access to the contents here
+//I'm making sure only one thread at a time has access to the contents here
 unsafe impl<E> Sync for FunTask<E> where E: Executor + Sync + 'static {}
 
 #[cfg(test)]

--- a/executors/src/futures_executor.rs
+++ b/executors/src/futures_executor.rs
@@ -1,0 +1,178 @@
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
+// file at the top-level directory of this distribution.
+//
+// Licensed under the MIT license
+// <LICENSE or http://opensource.org/licenses/MIT>.
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::*;
+use futures::{
+    future::{BoxFuture, FutureExt},
+    task::{waker_ref, ArcWake},
+};
+use std::{
+    cell::UnsafeCell,
+    future::Future,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub trait FuturesExecutor: Executor + Sync + 'static {
+    fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) -> ();
+}
+impl<E> FuturesExecutor for E
+where
+    E: Executor + Sync + 'static,
+{
+    fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) -> () {
+        let future = future.boxed();
+        let task = FunTask {
+            future: UnsafeCell::new(Some(future)),
+            executor: self.clone(),
+        };
+        let task = Arc::new(task);
+        self.execute(move || FunTask::run(task));
+    }
+}
+
+struct FunTask<E>
+where
+    E: Executor + Sync + 'static,
+{
+    future: UnsafeCell<Option<BoxFuture<'static, ()>>>,
+    executor: E,
+}
+
+impl<E> FunTask<E>
+where
+    E: Executor + Sync + 'static,
+{
+    fn run(task: Arc<Self>) -> () {
+        let res = unsafe {
+            let src = task.future.get();
+            src.as_mut().map(|opt| opt.take()).flatten()
+        };
+        if let Some(mut f) = res {
+            let waker = waker_ref(&task);
+            let context = &mut Context::from_waker(&*waker);
+            // `BoxFuture<T>` is a type alias for
+            // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
+            // We can get a `Pin<&mut dyn Future + Send + 'static>`
+            // from it by calling the `Pin::as_mut` method.
+            if let Poll::Pending = f.as_mut().poll(context) {
+                // We're not done processing the future, so put it
+                // back in its task to be run again in the future.
+                unsafe {
+                    let dst = task.future.get();
+                    if let Some(slot) = dst.as_mut() {
+                        *slot = Some(f);
+                    }
+                }
+            }
+        } // else the future is already done with
+    }
+}
+
+impl<E> ArcWake for FunTask<E>
+where
+    E: Executor + Sync + 'static,
+{
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        // Implement `wake` by sending this task back onto the task channel
+        // so that it will be polled again by the executor.
+        let cloned = arc_self.clone();
+        arc_self.executor.execute(move || FunTask::run(cloned));
+    }
+}
+
+// I'm making sure only one thread at a time has access to the contents here
+unsafe impl<E> Sync for FunTask<E> where E: Executor + Sync + 'static {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::channel::oneshot::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    async fn just_succeed(barrier: Arc<AtomicBool>) -> () {
+        let res = barrier.compare_and_swap(false, true, Ordering::SeqCst);
+        assert!(!res); //  i.e. assert that the old value was false
+    }
+
+    #[test]
+    fn test_async_ready_ccp() {
+        let exec = crate::crossbeam_channel_pool::ThreadPool::new(2);
+        test_async_ready_executor(&exec);
+        exec.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn test_async_ready_cwp() {
+        let exec = crate::crossbeam_workstealing_pool::small_pool(2);
+        test_async_ready_executor(&exec);
+        exec.shutdown().expect("shutdown");
+    }
+
+    fn test_async_ready_executor<E>(exec: &E)
+    where
+        E: FuturesExecutor,
+    {
+        let barrier = Arc::new(AtomicBool::new(false));
+        let f = just_succeed(barrier.clone());
+        exec.spawn(f);
+        let mut done = false;
+        while !done {
+            thread::sleep(Duration::from_millis(100));
+            done = barrier.load(Ordering::SeqCst);
+        }
+    }
+
+    async fn wait_for_channel(receiver: Receiver<()>, barrier: Arc<AtomicBool>) -> () {
+        let _ok = receiver.await.expect("message");
+        let res = barrier.compare_and_swap(false, true, Ordering::SeqCst);
+        assert!(!res); //  i.e. assert that the old value was false
+    }
+
+    // Does not implement Sync
+    // #[test]
+    // fn test_async_pending_tpe() {
+    // 	let exec = crate::threadpool_executor::ThreadPoolExecutor::new(2);
+    // 	test_async_pending_executor(&exec);
+    // 	exec.shutdown().expect("shutdown");
+    // }
+
+    #[test]
+    fn test_async_pending_ccp() {
+        let exec = crate::crossbeam_channel_pool::ThreadPool::new(2);
+        test_async_pending_executor(&exec);
+        exec.shutdown().expect("shutdown");
+    }
+
+    #[test]
+    fn test_async_pending_cwp() {
+        let exec = crate::crossbeam_workstealing_pool::small_pool(2);
+        test_async_pending_executor(&exec);
+        exec.shutdown().expect("shutdown");
+    }
+
+    fn test_async_pending_executor<E>(exec: &E)
+    where
+        E: FuturesExecutor,
+    {
+        let barrier = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = channel();
+        let f = wait_for_channel(rx, barrier.clone());
+        exec.spawn(f);
+        thread::sleep(Duration::from_millis(100));
+        tx.send(()).expect("sent");
+        let mut done = false;
+        while !done {
+            thread::sleep(Duration::from_millis(100));
+            done = barrier.load(Ordering::SeqCst);
+        }
+    }
+}

--- a/executors/src/futures_executor.rs
+++ b/executors/src/futures_executor.rs
@@ -6,6 +6,11 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Support for Rust's futures and async/await APIs
+//!
+//! This functionality is provided via the [FuturesExecutor](FuturesExecutor)
+//! trait, which is implemented for all executors in this crate that can efficiently support it.
+
 use super::*;
 use std::future::Future;
 
@@ -17,6 +22,22 @@ pub trait FuturesExecutor: Executor + Sync + 'static {
     /// Spawn `future` on the pool and return a handle to the result
     ///
     /// Handles can be awaited like any other future.
+    ///
+    /// # Examples
+    ///
+    /// Execute an "expensive" computation on the pool and 
+    /// block the main thread waiting for the result to become available.
+    ///
+    /// ```
+    /// use executors::*;
+    /// use futures::executor::block_on;
+    /// # use executors::crossbeam_channel_pool::ThreadPool;
+    /// // initialise some executor
+    /// # let executor = ThreadPool::new(2);
+    /// let handle = executor.spawn(async move { 2*2 });
+    /// let result = block_on(handle).expect("result");
+    /// assert_eq!(4, result);
+    /// ```
     fn spawn<R: Send + 'static>(
         &self,
         future: impl Future<Output = R> + 'static + Send,

--- a/executors/src/futures_executor.rs
+++ b/executors/src/futures_executor.rs
@@ -36,7 +36,7 @@ where
     }
 }
 
-struct FunTask<E>
+pub(crate) struct FunTask<E>
 where
     E: Executor + Sync + 'static,
 {

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::common::{CanExecute, Executor};
 #[cfg(any(feature = "cb-channel-exec", feature = "workstealing-exec"))]
 pub mod futures_executor;
 #[cfg(any(feature = "cb-channel-exec", feature = "workstealing-exec"))]
-pub use crate::futures_executor::FuturesExecutor;
+pub use crate::futures_executor::{FuturesExecutor, JoinHandle};
 
 //use bichannel::*;
 use synchronoise::CountdownEvent;

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license
@@ -32,6 +32,9 @@ mod timeconstants;
 
 use crate::common::ignore;
 pub use crate::common::Executor;
+
+#[cfg(feature = "futures-support")]
+pub mod futures_executor;
 
 //use bichannel::*;
 use synchronoise::CountdownEvent;

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -31,7 +31,7 @@ pub mod threadpool_executor;
 mod timeconstants;
 
 use crate::common::ignore;
-pub use crate::common::Executor;
+pub use crate::common::{CanExecute, Executor};
 
 #[cfg(feature = "futures-support")]
 pub mod futures_executor;
@@ -39,12 +39,14 @@ pub mod futures_executor;
 //use bichannel::*;
 use synchronoise::CountdownEvent;
 
-// TODO add default implementation for abstract executor impl with associated type executable
+mod locals;
+pub use locals::*;
 
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
     use std::fmt::Debug;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -122,6 +124,31 @@ pub(crate) mod tests {
         assert_eq!(res, 0);
     }
 
+    pub fn test_local<E>(exec: E, label: &str)
+    where
+        E: Executor + Debug + 'static,
+    {
+        let pool = exec;
+
+        let latch = Arc::new(CountdownEvent::new(N_DEPTH * N_WIDTH));
+        let failed = Arc::new(AtomicBool::new(false));
+        for _ in 0..N_WIDTH {
+            let latch2 = latch.clone();
+            let failed2 = failed.clone();
+            pool.execute(move || {
+                do_step_local(latch2, failed2, N_DEPTH);
+            });
+        }
+        let res = latch.wait_timeout(Duration::from_secs(30));
+        assert_eq!(res, 0);
+        assert!(
+            !failed.load(Ordering::SeqCst),
+            "Executor does not support local scheduling!"
+        );
+        pool.shutdown()
+            .unwrap_or_else(|e| error!("Error during pool shutdown {:?} at {}", e, label));
+    }
+
     fn do_step<E>(latch: Arc<CountdownEvent>, pool: E, depth: usize)
     where
         E: Executor + Debug + 'static,
@@ -131,6 +158,35 @@ pub(crate) mod tests {
         if (new_depth > 0) {
             let pool2 = pool.clone();
             pool.execute(move || do_step(latch, pool2, new_depth))
+        }
+    }
+
+    fn do_step_local(latch: Arc<CountdownEvent>, failed: Arc<AtomicBool>, depth: usize) {
+        let new_depth = depth - 1;
+        match latch.decrement() {
+            Ok(_) => {
+                if (new_depth > 0) {
+                    let failed2 = failed.clone();
+                    let latch2 = latch.clone();
+                    let res =
+                        try_execute_locally(move || do_step_local(latch2, failed2, new_depth));
+                    if res.is_err() {
+                        error!("do_step_local should have executed locally!");
+                        failed.store(true, Ordering::SeqCst);
+                        while latch.decrement().is_ok() {
+                            () // do nothing, just keep draining, so the main thread wakes up
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                if failed.load(Ordering::SeqCst) {
+                    warn!("Aborting test as it failed");
+                // and simply return here
+                } else {
+                    panic!("Latch didn't decrement! Error: {:?}", e);
+                }
+            }
         }
     }
 }

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -5,7 +5,8 @@
 // <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed
 // except according to those terms.
-#![doc(html_root_url = "https://docs.rs/executors/0.6.1")]
+#![doc(html_root_url = "https://docs.rs/executors/0.7.0")]
+#![deny(missing_docs)]
 #![allow(unused_parens)]
 #![allow(clippy::unused_unit)]
 

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -33,8 +33,10 @@ mod timeconstants;
 use crate::common::ignore;
 pub use crate::common::{CanExecute, Executor};
 
-#[cfg(feature = "futures-support")]
+#[cfg(any(feature = "cb-channel-exec", feature = "workstealing-exec"))]
 pub mod futures_executor;
+#[cfg(any(feature = "cb-channel-exec", feature = "workstealing-exec"))]
+pub use crate::futures_executor::FuturesExecutor;
 
 //use bichannel::*;
 use synchronoise::CountdownEvent;

--- a/executors/src/locals.rs
+++ b/executors/src/locals.rs
@@ -1,0 +1,59 @@
+use super::*;
+use std::cell::UnsafeCell;
+
+// UnsafeCell has 10x the performance of RefCell
+// and the scoping guarantees that the borrows are exclusive
+thread_local!(
+    static LOCAL_EXECUTOR: UnsafeCell<Option<Box<dyn CanExecute>>> = UnsafeCell::new(Option::None);
+);
+
+pub(crate) fn set_local_executor<E>(executor: E)
+where
+    E: CanExecute + 'static,
+{
+    LOCAL_EXECUTOR.with(move |e| unsafe {
+        *e.get() = Some(Box::new(executor));
+    });
+}
+
+pub(crate) fn unset_local_executor() {
+    LOCAL_EXECUTOR.with(move |e| unsafe {
+        *e.get() = None;
+    });
+}
+
+/// Tries run the job on the same executor that spawned the thread running the job.
+///
+/// This is not supported on all executor implementations,
+/// and will return `Err` variant with the original job if it can't be scheduled.
+pub fn try_execute_locally<F>(f: F) -> Result<(), F>
+where
+    F: FnOnce() + Send + 'static,
+{
+    LOCAL_EXECUTOR.with(move |e| {
+        if let Some(Some(ref boxed)) = unsafe { e.get().as_ref() } {
+            boxed.execute_job(Box::new(f));
+            Ok(())
+        } else {
+            Err(f)
+        }
+    })
+}
+
+// #[cfg(feature = "futures-support")]
+// mod futures_locals {
+// 	use super::*;
+// 	use crate::futures_executor::FuturesExecutor;
+
+// 	// UnsafeCell has 10x the performance of RefCell
+// // and the scoping guarantees that the borrows are exclusive
+// thread_local!(
+//     static LOCAL_FUTURES_EXECUTOR: UnsafeCell<Option<Box<dyn FuturesExecutor>>> = UnsafeCell::new(Option::None);
+// );
+
+// pub fn set_local_futures_executor<E>(executor: E) where E: FuturesExecutor {
+//     LOCAL_FUTURES_EXECUTOR.with(move |e| unsafe {
+//     	*e.get() = Some(Box::new(executor));
+//     });
+// }
+// }

--- a/executors/src/parker.rs
+++ b/executors/src/parker.rs
@@ -39,7 +39,7 @@ pub enum ParkResult {
     Woken,
 }
 
-pub trait Parker: Send + Clone {
+pub trait Parker: Sync + Send + Clone {
     /// Maximum number of threads supported by this parker implementation.
     fn max_threads(&self) -> Option<usize>;
 

--- a/executors/src/parker.rs
+++ b/executors/src/parker.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/run_now.rs
+++ b/executors/src/run_now.rs
@@ -6,7 +6,10 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A simple `Executor` that simply runs tasks on the current thread.
+//! A simple `Executor` that simply runs tasks immediately on the current thread.
+//!
+//! This is mostly useful to work with APIs that require an `Executor`,
+//! even if "normal" stack-based execution is actually desired.
 //!
 //! # Examples
 //!
@@ -32,6 +35,9 @@ use super::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+/// A handle to the [run_now](run_now) executor
+///
+/// See module level documentation for usage information.
 #[derive(Clone, Debug)]
 pub struct RunNowExecutor {
     active: Arc<AtomicBool>,
@@ -45,6 +51,7 @@ impl CanExecute for ThreadLocalRunNow {
 }
 
 impl RunNowExecutor {
+    /// Create a new [run_now](run_now) executor
     pub fn new() -> RunNowExecutor {
         RunNowExecutor {
             active: Arc::new(AtomicBool::new(true)),

--- a/executors/src/run_now.rs
+++ b/executors/src/run_now.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/threadpool_executor.rs
+++ b/executors/src/threadpool_executor.rs
@@ -85,7 +85,18 @@ impl Default for ThreadPoolExecutor {
     }
 }
 
+impl CanExecute for ThreadPoolExecutor {
+    fn execute_job(&self, job: Box<dyn FnOnce() + Send + 'static>) {
+        if self.active.load(Ordering::SeqCst) {
+            self.pool.execute(job);
+        } else {
+            warn!("Ignoring job as pool is shutting down.");
+        }
+    }
+}
+
 impl Executor for ThreadPoolExecutor {
+    // override this here instead of using the default implementation to avoid double boxing
     fn execute<F>(&self, job: F)
     where
         F: FnOnce() + Send + 'static,
@@ -119,12 +130,11 @@ impl Executor for ThreadPoolExecutor {
 
 #[cfg(test)]
 mod tests {
-    use env_logger;
 
     use super::*;
     use std::time::Duration;
 
-    const LABEL: &'static str = "Threadpool";
+    const LABEL: &str = "Threadpool";
 
     #[test]
     fn test_debug() {
@@ -143,6 +153,13 @@ mod tests {
     #[test]
     fn test_defaults() {
         crate::tests::test_defaults::<ThreadPoolExecutor>(LABEL);
+    }
+
+    #[test]
+    #[should_panic] // this executor does not actually support local scheduling
+    fn test_local() {
+        let exec = ThreadPoolExecutor::default();
+        crate::tests::test_local(exec, LABEL);
     }
 
     #[test]

--- a/executors/src/threadpool_executor.rs
+++ b/executors/src/threadpool_executor.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 Lars Kroll. See the LICENSE
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license

--- a/executors/src/threadpool_executor.rs
+++ b/executors/src/threadpool_executor.rs
@@ -43,6 +43,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use threadpool::ThreadPool;
 
+/// A handle to a [threadpool_executor](threadpool_executor)
+///
+/// See module level documentation for usage information.
 #[derive(Clone, Debug)]
 pub struct ThreadPoolExecutor {
     pool: ThreadPool,


### PR DESCRIPTION
This PR provides Async/Await support for most executor implementations.

I can provide implementations for all the others, too, if there is demand, but they'd be fairly inefficient compared to the provided ones. With the exception of the `RunNowExecutor`, which would simply be a wrapper around [block_on](https://docs.rs/futures/latest/futures/executor/fn.block_on.html).

Fixes #5.