### PR TITLE
Partial NUMA Aware Workstealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-executors = "0.7"
+executors = "0.8"
 ```
 
 You can use, for example, the [crossbeam_workstealing_pool](https://docs.rs/executors/latest/executors/crossbeam_workstealing_pool/index.html) to schedule a number `n_jobs` over a number `n_workers` threads, and collect the results via an `mpsc::channel`.

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -3,7 +3,7 @@ name = "executors"
 # NB: When modifying, also modify:
 #   1. html_root_url in lib.rs
 #   2. number in readme (for breaking changes)
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Lars Kroll <lkroll@kth.se>"]
 edition = "2018"
 description = "A collection of high-performance task executors."
@@ -16,7 +16,7 @@ categories = ["concurrency", "asynchronous"]
 license = "MIT"
 
 [features]
-default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults", "numa-aware"]
+default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults"]
 
 threadpool-exec = ["threadpool"]
 cb-channel-exec = ["crossbeam-channel", "async-task"]
@@ -31,8 +31,7 @@ ws-timed-fairness = [] #["time"]
 ws-no-park = []
 
 thread-pinning = ["core_affinity"]
-# This requires the hwloc C library to be installed on your system
-numa-aware = ["hwloc2", "thread-pinning"]
+numa-aware = ["thread-pinning"]
 
 
 [dependencies]
@@ -47,7 +46,8 @@ rand 				= {version = "0.7", optional = true}
 num_cpus 			= {version = "1.12", optional = true}
 core_affinity 		= {version = "0.5", optional = true}
 async-task 			= {version = "3.0", optional = true}
-hwloc2 				= {version = "2.2", optional = true}
+# reintroduce one hwloc is more stable or replace if there's an alternative
+#hwloc2 				= {version = "2.2", optional = true}
 
 [dev-dependencies]
 env_logger 			= "0.7"

--- a/executors/Cargo.toml
+++ b/executors/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["concurrency", "asynchronous"]
 license = "MIT"
 
 [features]
-default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults"]
+default = ["threadpool-exec", "cb-channel-exec", "workstealing-exec", "ws-timed-fairness", "defaults", "numa-aware"]
 
 threadpool-exec = ["threadpool"]
 cb-channel-exec = ["crossbeam-channel", "async-task"]
@@ -31,6 +31,8 @@ ws-timed-fairness = [] #["time"]
 ws-no-park = []
 
 thread-pinning = ["core_affinity"]
+# This requires the hwloc C library to be installed on your system
+numa-aware = ["hwloc2", "thread-pinning"]
 
 
 [dependencies]
@@ -44,8 +46,8 @@ crossbeam-deque 	= {version = "0.7", optional = true}
 rand 				= {version = "0.7", optional = true}
 num_cpus 			= {version = "1.12", optional = true}
 core_affinity 		= {version = "0.5", optional = true}
-#futures 			= {version = "0.3", optional = true}
 async-task 			= {version = "3.0", optional = true}
+hwloc2 				= {version = "2.2", optional = true}
 
 [dev-dependencies]
 env_logger 			= "0.7"

--- a/executors/src/crossbeam_workstealing_pool.rs
+++ b/executors/src/crossbeam_workstealing_pool.rs
@@ -261,9 +261,9 @@ where
             let mut guard = pool.inner.core.lock().unwrap();
             let cores = core_affinity::get_core_ids().expect("core ids");
             let num_pinned = cores.len().min(threads);
-            for i in 0..num_pinned {
+            for core in cores.iter().take(num_pinned) {
                 pool.inner
-                    .spawn_worker_pinned(&mut guard, pool.inner.clone(), None, cores[i]);
+                    .spawn_worker_pinned(&mut guard, pool.inner.clone(), None, *core);
             }
             if num_pinned < threads {
                 let num_unpinned = threads - num_pinned;

--- a/executors/src/crossbeam_workstealing_pool.rs
+++ b/executors/src/crossbeam_workstealing_pool.rs
@@ -905,7 +905,7 @@ where
                     continue 'main; // only steal once before checking locally again
                 }
             }
-            failed_steal_attempts += 1;
+            failed_steal_attempts = failed_steal_attempts.saturating_add(1);
             snoozing = true;
             #[cfg(feature = "ws-no-park")]
             {

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -5,7 +5,7 @@
 // <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed
 // except according to those terms.
-#![doc(html_root_url = "https://docs.rs/executors/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/executors/0.8.0")]
 #![deny(missing_docs)]
 #![allow(unused_parens)]
 #![allow(clippy::unused_unit)]
@@ -26,7 +26,7 @@ pub mod crossbeam_channel_pool;
 #[cfg(feature = "workstealing-exec")]
 pub mod crossbeam_workstealing_pool;
 #[cfg(feature = "numa-aware")]
-mod numa_utils;
+pub mod numa_utils;
 pub mod parker;
 pub mod run_now;
 #[cfg(feature = "threadpool-exec")]

--- a/executors/src/lib.rs
+++ b/executors/src/lib.rs
@@ -25,6 +25,8 @@ pub mod common;
 pub mod crossbeam_channel_pool;
 #[cfg(feature = "workstealing-exec")]
 pub mod crossbeam_workstealing_pool;
+#[cfg(feature = "numa-aware")]
+mod numa_utils;
 pub mod parker;
 pub mod run_now;
 #[cfg(feature = "threadpool-exec")]

--- a/executors/src/numa_utils.rs
+++ b/executors/src/numa_utils.rs
@@ -1,0 +1,156 @@
+use hwloc2::{CpuBindFlags, ObjectType, Topology, TopologyObject};
+use std::collections::HashMap;
+
+/// A full distance matrix between all processing units on a system
+pub(crate) struct PUDistance {
+    distance_matrix: Box<[Box<[u32]>]>,
+}
+impl PUDistance {
+    pub(crate) fn from_topology() -> Result<Self, CalcError> {
+        let topo = Topology::new().ok_or(CalcError("Topology is unavailable.".to_string()))?;
+        let mut root_distances: HashMap<String, u32> = HashMap::new();
+        let pus = collect_root_distances(&mut root_distances, one_norm, &topo)?;
+        let mut distance_matrix: Vec<Vec<u32>> = Vec::with_capacity(pus.len());
+        let _ = fill_matrix(&mut distance_matrix, &root_distances, &pus)?;
+        let partially_boxed_matrix: Vec<Box<[u32]>> = distance_matrix
+            .into_iter()
+            .map(|row| row.into_boxed_slice())
+            .collect();
+        let boxed_matrix = partially_boxed_matrix.into_boxed_slice();
+        Ok(PUDistance {
+            distance_matrix: boxed_matrix,
+        })
+    }
+}
+
+type TopologyObjectNorm = fn(&TopologyObject) -> u32;
+
+fn one_norm(_object: &TopologyObject) -> u32 {
+    1
+}
+
+fn fill_matrix(
+    distance_matrix: &mut Vec<Vec<u32>>,
+    root_distances: &HashMap<String, u32>,
+    pus: &[&TopologyObject],
+) -> Result<(), CalcError> {
+    Ok(())
+}
+
+fn collect_root_distances<'a, 'b>(
+    distance_map: &'a mut HashMap<String, u32>,
+    norm: TopologyObjectNorm,
+    topology: &'b Topology,
+) -> Result<Box<[&'b TopologyObject]>, CalcError> {
+    let mut collector = DistanceCollector {
+        norm,
+        distance_map,
+        pus: Vec::new(),
+    };
+    println!("About to start at the root...");
+    let root = topology.object_at_root();
+    println!("Root is ok");
+    let root_name = root.name();
+    println!("Root name is ok");
+    println!("Root has name={}", root_name);
+    collector.descend(root, 0)?;
+    Ok(collector.pus.into_boxed_slice())
+}
+struct DistanceCollector<'a, 'b> {
+    norm: TopologyObjectNorm,
+    distance_map: &'a mut HashMap<String, u32>,
+    pus: Vec<&'b TopologyObject>,
+}
+impl<'a, 'b> DistanceCollector<'a, 'b> {
+    fn descend(&mut self, node: &'b TopologyObject, path_cost: u32) -> Result<(), CalcError> {
+        println!("Descending into node={}", node.name());
+        if self.distance_map.insert(node.name(), path_cost).is_some() {
+            return Err(CalcError(format!("Node at {} is not unique!", node.name())));
+        }
+        if node.object_type() == ObjectType::PU {
+            self.pus.push(node);
+            debug_assert_eq!(0, node.arity(), "PUs should have no children!");
+            Ok(())
+        } else {
+            let new_cost = path_cost + (self.norm)(node);
+            for i in 0..node.arity() {
+                self.descend(node.children()[i as usize], new_cost)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CalcError(String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn test_root_distance_collection() {
+        let topo = Topology::new().expect("topology");
+        let mut root_distances: HashMap<String, u32> = HashMap::new();
+        let pus = collect_root_distances(&mut root_distances, one_norm, &topo).expect("collection");
+        let pu_names: Vec<String> = pus.iter().map(|pu| pu.name()).collect();
+        println!("PUs: {:?}", pu_names);
+        println!("Distances: {:?}", root_distances);
+    }
+
+    #[test]
+    fn test_core_ids() {
+        use hwloc2::{CpuBindFlags, Topology};
+
+        let core_ids = core_affinity::get_core_ids().unwrap();
+        println!("cores: {:?}", core_ids);
+
+        let topo = Topology::new().unwrap();
+
+        for i in 0..topo.depth() {
+            println!("*** Objects at level {}", i);
+
+            for (idx, object) in topo.objects_at_depth(i).iter().enumerate() {
+                println!("{}: {}", idx, object);
+            }
+        }
+
+        // Show current binding
+        //topo.set_cpubind(Bitmap::from(1), CpuBindFlags::CPUBIND_THREAD).expect("thread binding");
+        core_affinity::set_for_current(core_ids[0]);
+        println!(
+            "Current CPU Binding: {:?}",
+            topo.get_cpubind(CpuBindFlags::CPUBIND_THREAD)
+        );
+
+        // Check if Process Binding for CPUs is supported
+        println!(
+            "CPU Binding (current process) supported: {}",
+            topo.support().cpu().set_current_process()
+        );
+        println!(
+            "CPU Binding (any process) supported: {}",
+            topo.support().cpu().set_process()
+        );
+
+        // Check if Thread Binding for CPUs is supported
+        println!(
+            "CPU Binding (current thread) supported: {}",
+            topo.support().cpu().set_current_thread()
+        );
+        println!(
+            "CPU Binding (any thread) supported: {}",
+            topo.support().cpu().set_thread()
+        );
+
+        // Check if Memory Binding is supported
+        println!(
+            "Memory Binding supported: {}",
+            topo.support().memory().set_current_process()
+        );
+
+        // Debug Print all the Support Flags
+        println!("All Flags:\n{:?}", topo.support());
+    }
+}

--- a/executors/src/numa_utils.rs
+++ b/executors/src/numa_utils.rs
@@ -215,6 +215,14 @@ mod tests {
         assert_eq!(1, pud.distance(core2, core1));
     }
 
+    #[test]
+    fn test_empty_pu_distance() {
+        let mat: Vec<Vec<i32>> = Vec::new();
+        let pud: ProcessingUnitDistance = mat.into_iter().collect();
+        let pud2 = ProcessingUnitDistance::empty();
+        assert_eq!(pud, pud2);
+    }
+
     /*
      * Unfinished. Continue this once the hwloc library is more stable
      */

--- a/executors/src/numa_utils.rs
+++ b/executors/src/numa_utils.rs
@@ -1,156 +1,285 @@
-use hwloc2::{CpuBindFlags, ObjectType, Topology, TopologyObject};
-use std::collections::HashMap;
+// Copyright 2017-2020 Lars Kroll. See the LICENSE
+// file at the top-level directory of this distribution.
+//
+// Licensed under the MIT license
+// <LICENSE or http://opensource.org/licenses/MIT>.
+// This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module contains helpers for executors that are NUMA-ware.
+//!
+//! In particular the [ProcessingUnitDistance](ProcessingUnitDistance) code,
+//! which allows a the description of costs associated with schedulling a function
+//! on a different processing unit than it was originally assigned to.
+
+//use hwloc2::{CpuBindFlags, ObjectType, Topology, TopologyObject};
+//use std::collections::HashMap;
+use core_affinity::CoreId;
+use std::iter::FromIterator;
 
 /// A full distance matrix between all processing units on a system
-pub(crate) struct PUDistance {
-    distance_matrix: Box<[Box<[u32]>]>,
+#[derive(Debug, PartialEq)]
+pub struct ProcessingUnitDistance {
+    distance_matrix: Box<[Box<[i32]>]>,
 }
-impl PUDistance {
-    pub(crate) fn from_topology() -> Result<Self, CalcError> {
-        let topo = Topology::new().ok_or(CalcError("Topology is unavailable.".to_string()))?;
-        let mut root_distances: HashMap<String, u32> = HashMap::new();
-        let pus = collect_root_distances(&mut root_distances, one_norm, &topo)?;
-        let mut distance_matrix: Vec<Vec<u32>> = Vec::with_capacity(pus.len());
-        let _ = fill_matrix(&mut distance_matrix, &root_distances, &pus)?;
-        let partially_boxed_matrix: Vec<Box<[u32]>> = distance_matrix
-            .into_iter()
-            .map(|row| row.into_boxed_slice())
-            .collect();
-        let boxed_matrix = partially_boxed_matrix.into_boxed_slice();
-        Ok(PUDistance {
-            distance_matrix: boxed_matrix,
-        })
-    }
-}
-
-type TopologyObjectNorm = fn(&TopologyObject) -> u32;
-
-fn one_norm(_object: &TopologyObject) -> u32 {
-    1
-}
-
-fn fill_matrix(
-    distance_matrix: &mut Vec<Vec<u32>>,
-    root_distances: &HashMap<String, u32>,
-    pus: &[&TopologyObject],
-) -> Result<(), CalcError> {
-    Ok(())
-}
-
-fn collect_root_distances<'a, 'b>(
-    distance_map: &'a mut HashMap<String, u32>,
-    norm: TopologyObjectNorm,
-    topology: &'b Topology,
-) -> Result<Box<[&'b TopologyObject]>, CalcError> {
-    let mut collector = DistanceCollector {
-        norm,
-        distance_map,
-        pus: Vec::new(),
-    };
-    println!("About to start at the root...");
-    let root = topology.object_at_root();
-    println!("Root is ok");
-    let root_name = root.name();
-    println!("Root name is ok");
-    println!("Root has name={}", root_name);
-    collector.descend(root, 0)?;
-    Ok(collector.pus.into_boxed_slice())
-}
-struct DistanceCollector<'a, 'b> {
-    norm: TopologyObjectNorm,
-    distance_map: &'a mut HashMap<String, u32>,
-    pus: Vec<&'b TopologyObject>,
-}
-impl<'a, 'b> DistanceCollector<'a, 'b> {
-    fn descend(&mut self, node: &'b TopologyObject, path_cost: u32) -> Result<(), CalcError> {
-        println!("Descending into node={}", node.name());
-        if self.distance_map.insert(node.name(), path_cost).is_some() {
-            return Err(CalcError(format!("Node at {} is not unique!", node.name())));
+impl ProcessingUnitDistance {
+    /// Create a new instance from the underlying distance matrix
+    ///
+    /// Distance matrices must be square.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the passed matrix is not square.
+    pub fn new(distance_matrix: Box<[Box<[i32]>]>) -> Self {
+        // make sure it's a square matrix
+        let num_rows = distance_matrix.len();
+        for row in distance_matrix.iter() {
+            assert_eq!(num_rows, row.len(), "A PU distance matrix must be square!");
         }
-        if node.object_type() == ObjectType::PU {
-            self.pus.push(node);
-            debug_assert_eq!(0, node.arity(), "PUs should have no children!");
-            Ok(())
-        } else {
-            let new_cost = path_cost + (self.norm)(node);
-            for i in 0..node.arity() {
-                self.descend(node.children()[i as usize], new_cost)?;
+        ProcessingUnitDistance { distance_matrix }
+    }
+
+    /// A completely empty matrix where all lookups will fail
+    ///
+    /// This can be used as a placeholder when compiling with feature numa-aware,
+    /// but not actually pinning any threads.
+    pub fn empty() -> Self {
+        ProcessingUnitDistance {
+            distance_matrix: Vec::new().into_boxed_slice(),
+        }
+    }
+
+    /// Materialise the `distance` function into a full matrix of `size` x `size`
+    ///
+    /// The `distance` function will be invoked with row_index as first argument
+    /// and column_index as second argument for each value in `0..size`.
+    /// Both indices should be interpreted as if they were `CoreId.id` values.
+    ///
+    /// The value for `distance(i, i)` should probably be 0, but it is unlikely that any code will rely on this.
+    pub fn from_function<F>(size: usize, distance: F) -> Self
+    where
+        F: Fn(usize, usize) -> i32,
+    {
+        let mut matrix: Vec<Box<[i32]>> = Vec::with_capacity(size);
+        for row_index in 0..size {
+            let mut row: Vec<i32> = Vec::with_capacity(size);
+            for column_index in 0..size {
+                let d = distance(row_index, column_index);
+                row.push(d);
             }
-            Ok(())
+            matrix.push(row.into_boxed_slice());
         }
+        ProcessingUnitDistance {
+            distance_matrix: matrix.into_boxed_slice(),
+        }
+    }
+
+    /// Get the weighted distance between `pu1` and `pu2` according to this matrix.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if core ids are outside of the matrix bounds.
+    pub fn distance(&self, pu1: CoreId, pu2: CoreId) -> i32 {
+        self.distance_matrix[pu1.id][pu2.id]
+    }
+
+    // Unfinished. Continue this once the hwloc library is more stable
+    // pub fn from_topology() -> Result<Self, CalcError> {
+    //     let topo = Topology::new().ok_or(CalcError("Topology is unavailable.".to_string()))?;
+    //     let mut root_distances: HashMap<String, u32> = HashMap::new();
+    //     let pus = collect_root_distances(&mut root_distances, one_norm, &topo)?;
+    //     let mut distance_matrix: Vec<Vec<u32>> = Vec::with_capacity(pus.len());
+    //     let _ = fill_matrix(&mut distance_matrix, &root_distances, &pus)?;
+    //     let partially_boxed_matrix: Vec<Box<[u32]>> = distance_matrix
+    //         .into_iter()
+    //         .map(|row| row.into_boxed_slice())
+    //         .collect();
+    //     let boxed_matrix = partially_boxed_matrix.into_boxed_slice();
+    //     Ok(PUDistance {
+    //         distance_matrix: boxed_matrix,
+    //     })
+    // }
+}
+
+impl FromIterator<Vec<i32>> for ProcessingUnitDistance {
+    fn from_iter<I: IntoIterator<Item = Vec<i32>>>(iter: I) -> Self {
+        let mut v: Vec<Box<[i32]>> = Vec::new();
+        for i in iter {
+            v.push(i.into_boxed_slice());
+        }
+        ProcessingUnitDistance::new(v.into_boxed_slice())
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CalcError(String);
+impl FromIterator<Box<[i32]>> for ProcessingUnitDistance {
+    fn from_iter<I: IntoIterator<Item = Box<[i32]>>>(iter: I) -> Self {
+        let mut v: Vec<Box<[i32]>> = Vec::new();
+        for i in iter {
+            v.push(i);
+        }
+        ProcessingUnitDistance::new(v.into_boxed_slice())
+    }
+}
+
+/// Trivial distance function for non-NUMA architectures
+///
+/// Produces a 0 distance for `i==j` and 1 otherwise.
+pub fn equidistance(i: usize, j: usize) -> i32 {
+    if i == j {
+        0
+    } else {
+        1
+    }
+}
+
+/*
+* Unfinished. Continue this once the hwloc library is more stable
+*/
+
+// type TopologyObjectNorm = fn(&TopologyObject) -> u32;
+
+// fn one_norm(_object: &TopologyObject) -> u32 {
+//     1
+// }
+
+// fn fill_matrix(
+//     distance_matrix: &mut Vec<Vec<u32>>,
+//     root_distances: &HashMap<String, u32>,
+//     pus: &[&TopologyObject],
+// ) -> Result<(), CalcError> {
+//     Ok(())
+// }
+
+// fn collect_root_distances<'a, 'b>(
+//     distance_map: &'a mut HashMap<String, u32>,
+//     norm: TopologyObjectNorm,
+//     topology: &'b Topology,
+// ) -> Result<Box<[&'b TopologyObject]>, CalcError> {
+//     let mut collector = DistanceCollector {
+//         norm,
+//         distance_map,
+//         pus: Vec::new(),
+//     };
+//     println!("About to start at the root...");
+//     let root = topology.object_at_root();
+//     println!("Root is ok");
+//     let root_name = root.name();
+//     println!("Root name is ok");
+//     println!("Root has name={}", root_name);
+//     collector.descend(root, 0)?;
+//     Ok(collector.pus.into_boxed_slice())
+// }
+// struct DistanceCollector<'a, 'b> {
+//     norm: TopologyObjectNorm,
+//     distance_map: &'a mut HashMap<String, u32>,
+//     pus: Vec<&'b TopologyObject>,
+// }
+// impl<'a, 'b> DistanceCollector<'a, 'b> {
+//     fn descend(&mut self, node: &'b TopologyObject, path_cost: u32) -> Result<(), CalcError> {
+//         println!("Descending into node={}", node.name());
+//         if self.distance_map.insert(node.name(), path_cost).is_some() {
+//             return Err(CalcError(format!("Node at {} is not unique!", node.name())));
+//         }
+//         if node.object_type() == ObjectType::PU {
+//             self.pus.push(node);
+//             debug_assert_eq!(0, node.arity(), "PUs should have no children!");
+//             Ok(())
+//         } else {
+//             let new_cost = path_cost + (self.norm)(node);
+//             for i in 0..node.arity() {
+//                 self.descend(node.children()[i as usize], new_cost)?;
+//             }
+//             Ok(())
+//         }
+//     }
+// }
+
+// #[derive(Debug, Clone)]
+// pub(crate) struct CalcError(String);
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-
     #[test]
-    fn test_root_distance_collection() {
-        let topo = Topology::new().expect("topology");
-        let mut root_distances: HashMap<String, u32> = HashMap::new();
-        let pus = collect_root_distances(&mut root_distances, one_norm, &topo).expect("collection");
-        let pu_names: Vec<String> = pus.iter().map(|pu| pu.name()).collect();
-        println!("PUs: {:?}", pu_names);
-        println!("Distances: {:?}", root_distances);
+    fn test_pu_distance_creation() {
+        let mat = vec![vec![0, 1], vec![1, 0]];
+        let pud: ProcessingUnitDistance = mat.into_iter().collect();
+        let pud2 = ProcessingUnitDistance::from_function(2, equidistance);
+        assert_eq!(pud, pud2);
+        let core1 = CoreId { id: 0 };
+        let core2 = CoreId { id: 1 };
+        assert_eq!(0, pud.distance(core1, core1));
+        assert_eq!(0, pud.distance(core2, core2));
+        assert_eq!(1, pud.distance(core1, core2));
+        assert_eq!(1, pud.distance(core2, core1));
     }
 
-    #[test]
-    fn test_core_ids() {
-        use hwloc2::{CpuBindFlags, Topology};
+    /*
+     * Unfinished. Continue this once the hwloc library is more stable
+     */
+    // #[test]
+    // fn test_root_distance_collection() {
+    //     let topo = Topology::new().expect("topology");
+    //     let mut root_distances: HashMap<String, u32> = HashMap::new();
+    //     let pus = collect_root_distances(&mut root_distances, one_norm, &topo).expect("collection");
+    //     let pu_names: Vec<String> = pus.iter().map(|pu| pu.name()).collect();
+    //     println!("PUs: {:?}", pu_names);
+    //     println!("Distances: {:?}", root_distances);
+    // }
 
-        let core_ids = core_affinity::get_core_ids().unwrap();
-        println!("cores: {:?}", core_ids);
+    // #[test]
+    // fn test_core_ids() {
+    //     use hwloc2::{CpuBindFlags, Topology};
 
-        let topo = Topology::new().unwrap();
+    //     let core_ids = core_affinity::get_core_ids().unwrap();
+    //     println!("cores: {:?}", core_ids);
 
-        for i in 0..topo.depth() {
-            println!("*** Objects at level {}", i);
+    //     let topo = Topology::new().unwrap();
 
-            for (idx, object) in topo.objects_at_depth(i).iter().enumerate() {
-                println!("{}: {}", idx, object);
-            }
-        }
+    //     for i in 0..topo.depth() {
+    //         println!("*** Objects at level {}", i);
 
-        // Show current binding
-        //topo.set_cpubind(Bitmap::from(1), CpuBindFlags::CPUBIND_THREAD).expect("thread binding");
-        core_affinity::set_for_current(core_ids[0]);
-        println!(
-            "Current CPU Binding: {:?}",
-            topo.get_cpubind(CpuBindFlags::CPUBIND_THREAD)
-        );
+    //         for (idx, object) in topo.objects_at_depth(i).iter().enumerate() {
+    //             println!("{}: {}", idx, object);
+    //         }
+    //     }
 
-        // Check if Process Binding for CPUs is supported
-        println!(
-            "CPU Binding (current process) supported: {}",
-            topo.support().cpu().set_current_process()
-        );
-        println!(
-            "CPU Binding (any process) supported: {}",
-            topo.support().cpu().set_process()
-        );
+    //     // Show current binding
+    //     //topo.set_cpubind(Bitmap::from(1), CpuBindFlags::CPUBIND_THREAD).expect("thread binding");
+    //     core_affinity::set_for_current(core_ids[0]);
+    //     println!(
+    //         "Current CPU Binding: {:?}",
+    //         topo.get_cpubind(CpuBindFlags::CPUBIND_THREAD)
+    //     );
 
-        // Check if Thread Binding for CPUs is supported
-        println!(
-            "CPU Binding (current thread) supported: {}",
-            topo.support().cpu().set_current_thread()
-        );
-        println!(
-            "CPU Binding (any thread) supported: {}",
-            topo.support().cpu().set_thread()
-        );
+    //     // Check if Process Binding for CPUs is supported
+    //     println!(
+    //         "CPU Binding (current process) supported: {}",
+    //         topo.support().cpu().set_current_process()
+    //     );
+    //     println!(
+    //         "CPU Binding (any process) supported: {}",
+    //         topo.support().cpu().set_process()
+    //     );
 
-        // Check if Memory Binding is supported
-        println!(
-            "Memory Binding supported: {}",
-            topo.support().memory().set_current_process()
-        );
+    //     // Check if Thread Binding for CPUs is supported
+    //     println!(
+    //         "CPU Binding (current thread) supported: {}",
+    //         topo.support().cpu().set_current_thread()
+    //     );
+    //     println!(
+    //         "CPU Binding (any thread) supported: {}",
+    //         topo.support().cpu().set_thread()
+    //     );
 
-        // Debug Print all the Support Flags
-        println!("All Flags:\n{:?}", topo.support());
-    }
+    //     // Check if Memory Binding is supported
+    //     println!(
+    //         "Memory Binding supported: {}",
+    //         topo.support().memory().set_current_process()
+    //     );
+
+    //     // Debug Print all the Support Flags
+    //     println!("All Flags:\n{:?}", topo.support());
+    // }
 }

--- a/executors/test-features.sh
+++ b/executors/test-features.sh
@@ -8,21 +8,21 @@ cargo test -- "$@"
 echo "%%%%%% Finished testing default features %%%%%%"
 
 echo "%%%%%% Testing feature ws-no-park %%%%%%"
-cargo clippy --features ws-no-park
+cargo clippy --features ws-no-park -- -D warnings
 cargo test --features ws-no-park -- "$@"
 echo "%%%%%% Finished testing feature ws-no-park %%%%%%"
 
 echo "%%%%%% Testing feature !ws-timed-fairness %%%%%%"
-cargo clippy --no-default-features  --features threadpool-exec,cb-channel-exec,workstealing-exec,defaults,thread-pinning
+cargo clippy --no-default-features  --features threadpool-exec,cb-channel-exec,workstealing-exec,defaults,thread-pinning -- -D warnings
 cargo test --no-default-features  --features threadpool-exec,cb-channel-exec,workstealing-exec,defaults,thread-pinning -- "$@"
 echo "%%%%%% Finished testing feature !ws-timed-fairness %%%%%%"
 
 echo "%%%%%% Testing feature thread-pinning %%%%%%"
-cargo clippy --features thread-pinning
+cargo clippy --features thread-pinning -- -D warnings
 cargo test --features thread-pinning -- "$@"
 echo "%%%%%% Finished testing feature thread-pinning %%%%%%"
 
 echo "%%%%%% Testing feature numa-aware %%%%%%"
-cargo clippy --features numa-aware
+cargo clippy --features numa-aware -- -D warnings
 cargo test --features numa-aware -- "$@"
 echo "%%%%%% Finished testing feature numa-aware %%%%%%"

--- a/executors/test-features.sh
+++ b/executors/test-features.sh
@@ -21,3 +21,8 @@ echo "%%%%%% Testing feature thread-pinning %%%%%%"
 cargo clippy --features thread-pinning
 cargo test --features thread-pinning -- "$@"
 echo "%%%%%% Finished testing feature thread-pinning %%%%%%"
+
+echo "%%%%%% Testing feature numa-aware %%%%%%"
+cargo clippy --features numa-aware
+cargo test --features numa-aware -- "$@"
+echo "%%%%%% Finished testing feature numa-aware %%%%%%"


### PR DESCRIPTION
This PR introduces a restriction on the work-stealing scheduler (`crossbeam_workstealing_pool`) to prioritise stealing for "closer" processing units (PUs) and potentially prevent stealing "too distant" PUs.

The mechanism for this is based on a *distance matrix* between PUs, where lower distance increases work-stealing from that PU. In order to heavily penalise far away PUs, the approach counts work-stealing attempts at low_distance PUs and only moves on to further away ones after a certain number of failed attempts. Failed attempts are reset when work-stealing succeeds or the worker handles any other work. Very high distances may mean that stealing is never attempted from that PU, as the worker may go to sleep (park) before reaching such a high value.

The mechanism described above is activated via the new `numa-aware` Cargo feature flag.

### Limitations

As already discussed in #8, this PR does currently not attempt any system topology detection or interpretation. How the PU distance matrix is produced is up to the user at this point. It could be hardcoded for a particular machine, or read from a configuration file (potentially produced from some thing based on hwloc) or any other mechanism imaginable.

### Related Issues

This PR partially addresses #8, but should not close it when merged.